### PR TITLE
Remove explicit versions for dependencies where specced via constrain…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,8 +67,6 @@ allprojects {
         // These constraints apply to direct and indirect dependencies, in addition
         // to the versions specified by enforcedPlatform (in dependency below)
         constraints {
-            // This applies constraints so that we use same dependency versions as egeria
-            implementation enforcedPlatform("org.odpi.egeria:egeria:${egeriaversion}")
             // test dependencies
             testCompileOnly "org.junit.jupiter:junit-jupiter-api:${jupiterVersion}"
             testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}"

--- a/cataloguing-data/areas-frequent-travellers/build.gradle
+++ b/cataloguing-data/areas-frequent-travellers/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/cataloguing-data/map-data-GHG/build.gradle
+++ b/cataloguing-data/map-data-GHG/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/cataloguing-data/reference-mapping/build.gradle
+++ b/cataloguing-data/reference-mapping/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/cataloguing-data/utility-bill/build.gradle
+++ b/cataloguing-data/utility-bill/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/cataloguing-data/value-set-GHG/build.gradle
+++ b/cataloguing-data/value-set-GHG/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/cfc-free-certification-type/build.gradle
+++ b/governance-program/cfc-free-certification-type/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/people-at-locations/build.gradle
+++ b/governance-program/people-at-locations/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-aspects/build.gradle
+++ b/governance-program/sustainability-aspects/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-community/build.gradle
+++ b/governance-program/sustainability-community/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-glossary/build.gradle
+++ b/governance-program/sustainability-glossary/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-governance-definitions/build.gradle
+++ b/governance-program/sustainability-governance-definitions/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-governance-domain/build.gradle
+++ b/governance-program/sustainability-governance-domain/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-governance-zone/build.gradle
+++ b/governance-program/sustainability-governance-zone/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-leader/build.gradle
+++ b/governance-program/sustainability-leader/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-metadata-server/build.gradle
+++ b/governance-program/sustainability-metadata-server/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-metrics/build.gradle
+++ b/governance-program/sustainability-metrics/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-project/build.gradle
+++ b/governance-program/sustainability-project/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-subject-area/build.gradle
+++ b/governance-program/sustainability-subject-area/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/governance-program/sustainability-team-emails/build.gradle
+++ b/governance-program/sustainability-team-emails/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/it-systems/catalogue-it-systems/build.gradle
+++ b/it-systems/catalogue-it-systems/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/it-systems/list-no-lineage/build.gradle
+++ b/it-systems/list-no-lineage/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/it-systems/list-power-use/build.gradle
+++ b/it-systems/list-power-use/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/operations-inventory/add-new-site/build.gradle
+++ b/operations-inventory/add-new-site/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/operations-inventory/coolant-types/build.gradle
+++ b/operations-inventory/coolant-types/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/operations-inventory/inventory-to-do/build.gradle
+++ b/operations-inventory/inventory-to-do/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/operations-inventory/list-locations/build.gradle
+++ b/operations-inventory/list-locations/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/operations-inventory/list-systems-locations/build.gradle
+++ b/operations-inventory/list-systems-locations/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/operations-inventory/refrigeration-unit-types/build.gradle
+++ b/operations-inventory/refrigeration-unit-types/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/samples-ensemble/build.gradle
+++ b/samples-ensemble/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     implementation project(':governance-program:sustainability-project')
     implementation project(':governance-program:sustainability-subject-area')
     implementation project(':governance-program:sustainability-team-emails')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/sustainability-dashboard/catalogue-structure/build.gradle
+++ b/sustainability-dashboard/catalogue-structure/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/sustainability-dashboard/create-data-pipeline/build.gradle
+++ b/sustainability-dashboard/create-data-pipeline/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/sustainability-dashboard/data-sets-for-analysis/build.gradle
+++ b/sustainability-dashboard/data-sets-for-analysis/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/sustainability-dashboard/emissions-calcuations/build.gradle
+++ b/sustainability-dashboard/emissions-calcuations/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }

--- a/sustainability-dashboard/lineage-data-pipelines/build.gradle
+++ b/sustainability-dashboard/lineage-data-pipelines/build.gradle
@@ -10,8 +10,8 @@ plugins {
 
 dependencies {
     implementation project(':samples-utilities')
-    implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-    implementation("org.odpi.egeria:http-helper:${egeriaversion}")
+    implementation "org.odpi.egeria:open-connector-framework"
+    implementation("org.odpi.egeria:http-helper")
     runtimeOnly 'ch.qos.logback:logback-classic'
     compileOnly 'com.fasterxml.jackson.core:jackson-annotations'
 }


### PR DESCRIPTION
…t or platform

* Removes explicit references to egeriaVersion in subproject dependencies, since this is already controlled by constraints in the top level gradle file


Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>